### PR TITLE
cookie에서 login id제거

### DIFF
--- a/lib/php/src/Auth/LoginService.php
+++ b/lib/php/src/Auth/LoginService.php
@@ -6,7 +6,8 @@ class LoginService
 {
     const SESSION_TIMEOUT_SEC = 60 * 60 * 24 * 14; // 2주
     const ADMIN_ID_COOKIE_NAME = 'admin-id';
-    static $admin_id = '';
+
+    static $login_context;
 
     /**
      * @param string $id
@@ -60,12 +61,14 @@ class LoginService
 
     public static function GetAdminID()
     {
-        return self::$admin_id;
+        return self::$login_context->user_id ?? '';
     }
 
-    public static function setAdminID($admin_id)
+    public static function loadLoginContext(string $login_token)
     {
-        self::$admin_id = $admin_id;
+        self::$login_context = AdminAuthService::requestTokenIntrospect($login_token);
+
+        return isset(self::$login_context->user_id);
     }
 
     public static function startSession()

--- a/lib/php/src/Auth/LoginService.php
+++ b/lib/php/src/Auth/LoginService.php
@@ -6,6 +6,7 @@ class LoginService
 {
     const SESSION_TIMEOUT_SEC = 60 * 60 * 24 * 14; // 2주
     const ADMIN_ID_COOKIE_NAME = 'admin-id';
+    static $admin_id = '';
 
     /**
      * @param string $id
@@ -59,12 +60,12 @@ class LoginService
 
     public static function GetAdminID()
     {
-        return $_COOKIE[self::ADMIN_ID_COOKIE_NAME];
+        return self::$admin_id;
     }
 
     public static function setAdminID($admin_id)
     {
-        setcookie(self::ADMIN_ID_COOKIE_NAME, $admin_id, time() + self::SESSION_TIMEOUT_SEC, '', '', false, true);
+        self::$admin_id = $admin_id;
     }
 
     public static function startSession()


### PR DESCRIPTION
1. 현재 매번 메뉴 접근시마다 token-introspect를 하고있는데 이경우 login id를 쿠키에 저장해둘 필요가 없어 보여서 삭제했습니다. 
대신 미들웨어의 before단계에서 token-introspect후에 request 처리중에 login id를 사용하게 되는 일이 있어 이때를 위해 token-introspect시에 가져왔던 login id를 어딘가에 저장해둬야 합니다. 그건 LoginService의 static변수로 캐싱해서 쓰게 했습니다.

2. setAdminID를 LoginService에서 public 노출하는 대신 직접 Login처리하면서 login id를 스스로 세팅하도록 리팩터링했습니다.
