### PR TITLE
Remove PHP warning if a cookie is not set

### DIFF
--- a/lib/php/src/Auth/LoginService.php
+++ b/lib/php/src/Auth/LoginService.php
@@ -64,7 +64,7 @@ class LoginService
 
     public static function GetAdminID()
     {
-        return self::$login_context->user_id ?? $_COOKIE[self::ADMIN_ID_COOKIE_NAME];
+        return self::$login_context->user_id ?? ($_COOKIE[self::ADMIN_ID_COOKIE_NAME] ?? null);
     }
 
     public static function validateLogin(request $request)


### PR DESCRIPTION
토큰 쿠키가 없을 때 $_COOKIE가 비어있어 참조시 warning이 발생하는데, 그걸 방지해주기 위한 변경입니다.