### PR TITLE
Remove configs using global variable

### DIFF
--- a/lib/php/src/Auth/LoginService.php
+++ b/lib/php/src/Auth/LoginService.php
@@ -10,7 +10,7 @@ class LoginService
     const ADMIN_ID_COOKIE_NAME = 'admin-id';
     const TOKEN_COOKIE_NAME = 'cms-token';
 
-    static $login_context;
+    private static $login_context;
 
     /**
      * @param string $id

--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -26,7 +26,7 @@ class CmsApplication extends Application
     private function setDefaultErrorHandler()
     {
         $this->error(function (\Exception $e) {
-            if ($this['debug']) {
+            if (empty($this['debug'])) {
                 return null;
             }
 

--- a/lib/php/src/MiniRouter.php
+++ b/lib/php/src/MiniRouter.php
@@ -14,13 +14,15 @@ class MiniRouter
      * @var array
      */
     private $global_args;
+    private $debug;
 
-    public function __construct($controller_dir, $view_dir, $prefix_uri = '', $global_args = [])
+    public function __construct($controller_dir, $view_dir, $prefix_uri = '', $global_args = [], $debug = false)
     {
         $this->controller_dir = $controller_dir;
         $this->view_dir = $view_dir;
         $this->prefix_uri = self::getNormalizedUri($prefix_uri);
         $this->global_args = $global_args;
+        $this->debug = $debug;
     }
 
     /**
@@ -60,7 +62,7 @@ class MiniRouter
         $return_value = $this->callController($controller_path);
 
         if (is_array($return_value)) {
-            return $this->callView($request, $controller_path, $return_value);
+            return $this->callView($controller_path, $return_value);
         } elseif (is_string($return_value)) {
             return Response::create($return_value);
         } elseif ($return_value instanceof Response) {
@@ -112,18 +114,19 @@ class MiniRouter
     }
 
     /**
-     * @param Request $request
      * @param $query
      * @param array $args
      * @return Response
      */
-    private function callView($request, $query, $args)
+    private function callView($query, $args)
     {
         $view_file_name = $query . '.twig';
 
-        $app = new CmsApplication();
-        $app['twig.path'] = [$this->view_dir];
-        $app['twig.env.globals'] = $this->global_args;
+        $app = new CmsApplication([
+            'debug' => $this->debug,
+            'twig.globals' => $this->global_args,
+            'twig.path' => [$this->view_dir],
+        ]);
 
         /** @var \Twig_Environment $twig_helper */
         $twig_helper = $app['twig'];

--- a/lib/php/src/MiniRouter.php
+++ b/lib/php/src/MiniRouter.php
@@ -4,6 +4,8 @@ namespace Ridibooks\Cms;
 use Ridibooks\Cms\Auth\AdminAuthService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Twig_Environment;
+use Twig_Loader_Filesystem;
 
 class MiniRouter
 {
@@ -120,18 +122,17 @@ class MiniRouter
      */
     private function callView($query, $args)
     {
-        $view_file_name = $query . '.twig';
-
-        $app = new CmsApplication([
-            'debug' => $this->debug,
-            'twig.globals' => $this->global_args,
-            'twig.path' => [$this->view_dir],
+        $loader = new Twig_Loader_Filesystem([
+            __DIR__ . '/../views/',
+            $this->view_dir,
         ]);
 
-        /** @var \Twig_Environment $twig_helper */
-        $twig_helper = $app['twig'];
+        $twig = new Twig_Environment($loader, ['debug' => $this->debug]);
+        foreach ($this->global_args as $k => $v) {
+            $twig->addGlobal($k, $v);
+        }
 
-        return Response::create($twig_helper->render($view_file_name, $args));
+        return Response::create($twig->render($query . '.twig', $args));
     }
 
     private static function notFound()


### PR DESCRIPTION
#### 변경:
CmsApplication 내부에서 전역 변수를 참조하는 설정값을 제거하고, 생성자 인자로 외부에서 받도록 변경했습니다.

#### 사유:
각 서비스마다 필요한 설정값과 그 설정값이 저장된 곳이 다릅니다. (ex: config.local.php, .env)
하지만 지금은 모든 서비스의 경우를 고려해서, 각 서비스에서 사용하지도 않는 파일과 변수들을 읽고 있어 혼란스럽고, warning 이 발생하기도 합니다.   

이 이슈와도 관계가 있습니다.  -> https://app.asana.com/0/235684600038401/558828289911632/f
(현재는 static 리소스 url이 `/admin/static`으로 고정되어 있는데, cms-main 서버의 static 리소스를 사용하도록 변경할 수 있도록..)

변경을 적용하려면 SDK를 사용하는 서비스마다 코드를 다음 처럼 변경해야 합니다.

```php
// 변경 전 - CmsApplication 내부에서 설정값 다 읽음
$app = new CmsApplication();

// 변경 후 - CmsApplication에 인자로 설정값 넘김
$app = new CmsApplication([
    'debug' => $_ENV['DEBUG'],
    'twig.globals' => [
        'STATIC_URL' => $cms_rpc_url . '/static',
        'BOWER_PATH' => $cms_rpc_url . '/static/bower_components',
    ],
    'twig.path' => [
        __DIR__ . '/../views/'
    ],
    // ... 그 외 필요한 값들
]);
```
