### PR TITLE
Add omitted configuration in twig environment.

### DIFF
--- a/lib/php/src/MiniRouter.php
+++ b/lib/php/src/MiniRouter.php
@@ -128,9 +128,15 @@ class MiniRouter
         ]);
 
         $twig = new Twig_Environment($loader, ['debug' => $this->debug]);
+
+        $this->global_args = array_merge($this->global_args, [
+            'session_user_menu' => (new AdminAuthService())->getAdminMenu()
+        ]);
         foreach ($this->global_args as $k => $v) {
             $twig->addGlobal($k, $v);
         }
+
+        $twig->addFilter(new \Twig_SimpleFilter('strtotime', 'strtotime'));
 
         return Response::create($twig->render($query . '.twig', $args));
     }


### PR DESCRIPTION
#34 에서 누락된 부분이 있습니다.

### 버그 설명
PHP에서 Twig를 CmsApplicaion 클래스와 MiniRouter 클래스 두군데에서 생성해 사용하고 있습니다.  
그런데 CmsApplication twig에 존재하는 필터와 전역변수가  MiniRouter twig에는 빠져있습니다. (각각 `strtotime`, `session_user_menu`)

그래서 누락된 MiniRouter를 통해 페이지를 렌더링하면 `strtotime` 호출시 에러가 발생하거나 좌측 메뉴가 출력되지 않는 문제가 있습니다.

