### PR TITLE
Update callView function to render pages with CmsApplication

### DIFF
--- a/lib/php/src/MiniRouter.php
+++ b/lib/php/src/MiniRouter.php
@@ -122,17 +122,19 @@ class MiniRouter
      */
     private function callView($query, $args)
     {
-        $loader = new Twig_Loader_Filesystem([
-            __DIR__ . '/../views/',
-            $this->view_dir,
+        $view_file_name = $query . '.twig';
+
+        $app = new CmsApplication([
+            'debug' => $this->debug,
+            'twig.path' => [$this->view_dir],
+            'twig.globals' => $this->global_args,
         ]);
 
-        $twig = new Twig_Environment($loader, ['debug' => $this->debug]);
-        foreach ($this->global_args as $k => $v) {
-            $twig->addGlobal($k, $v);
-        }
+        /** @var \Twig_Environment $twig_helper */
+        $twig_helper = $app['twig'];
 
-        return Response::create($twig->render($query . '.twig', $args));
+        return Response::create($twig_helper->render($view_file_name, $args));
+
     }
 
     private static function notFound()

--- a/lib/php/src/MiniRouter.php
+++ b/lib/php/src/MiniRouter.php
@@ -4,8 +4,6 @@ namespace Ridibooks\Cms;
 use Ridibooks\Cms\Auth\AdminAuthService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Twig_Environment;
-use Twig_Loader_Filesystem;
 
 class MiniRouter
 {
@@ -134,7 +132,6 @@ class MiniRouter
         $twig_helper = $app['twig'];
 
         return Response::create($twig_helper->render($view_file_name, $args));
-
     }
 
     private static function notFound()


### PR DESCRIPTION
### 수정 배경:
#34 변경점에서 MiniRouter::callView 호출 시 독립적인 Twig 클래스 생성 후 렌더링하도록 수정했었습니다.
그렇게하면 렌더링 코드가 두군데가 되어 중복 관리해야 합니다. 또 Silex 시스템을 사용하지 않게되면서 사이드이펙트가 발생할 여지가 있습니다. (ex: FlashBag 기능)  

### 수정 내용:
다시 CmsApplication를 사용하도록 수정했습니다. 전역 변수는 외부에서 받아 사용합니다.