### PR TITLE
 Synchronize with released package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Ridibooks CMS SDK
 
+## 2.2.2 (2018-03-26)
+
+- [PHP] Redirect to /token-refresh on token expired
+- [PHP] Handle 400 error on token introspect
+
 ## 2.2.1 (2018-03-12)
 
 - [PHP] Fix `MiniRouter` compatiblitiy issue

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -13,7 +13,7 @@ setup(
         'ridi.cms.thrift.AdminUser',
         'ridi.cms.thrift.Errors',
     ],
-    version='2.2.1',
+    version='2.1.0',
     description='Ridi CMS SDK',
     url='https://github.com/ridi/cms-sdk',
     keywords=['cmssdk', 'ridi', 'ridibooks'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/cms-sdk",
-  "version": "2.2.1",
+  "version": "2.1.0",
   "description": "Ridibooks CMS SDK",
   "main": "./lib/js/dist/index.js",
   "dependencies": {


### PR DESCRIPTION
기존에 Python이나 js버전이 릴리즈 되지 않아도 PHP와 버전을 싱크시키고 있었는데, 앞으로는 실제 릴리즈된버전에 맞추기 위해 현재 릴리즈된 최신 버전으로 값을 되돌렸습니다.