### PR TITLE
Fix token-refresh failure due to domain mismatch

### DIFF
--- a/lib/php/src/Auth/LoginService.php
+++ b/lib/php/src/Auth/LoginService.php
@@ -124,7 +124,7 @@ class LoginService
         $request_uri = $request->getRequestUri();
 
         if (self::isTokenExpired()) {
-            $redirect_url = self::getRPCUrl() . '/token-refresh';
+            $redirect_url = '/v2/token-refresh';
         } else {
             $redirect_url = '/login';
         }


### PR DESCRIPTION
## 수정내용
/token-refresh가 안되는 문제를 수정했습니다.

## 원인
/token-refresh를 위해 도메인명을 RPC url에서 가져오게했는데(추후 /v2라는경로가 빠질경우의 유연성을위해) 이때문에 오히려 rpc url이 cms.ridibooks.com으로 세팅된 경우에 도메인이 달라서 쿠키 공유가 안되는 이슈가 있습니다. 어쩔수 없이 토큰 리프레쉬 endpoint를 `/v2/token-refresh`로 명시했습니다.