### PR TITLE
Release v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Ridibooks CMS SDK
 
 ## [Unreleased]
-- Add new `/authorizeByTag` API
+
+## [2.3.1] - 2018-04-19
+- [PHP, JS, Python] Add new `authorizeByTag` API
 
 ## [2.3.0] - 2018-04-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Ridibooks CMS SDK
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ## [2.3.1] - 2018-04-19
-- [PHP, JS, Python] Add new `authorizeByTag` API
+### Added
+- [PHP, JS, Python] new `authorizeByTag` API
 
 ## [2.3.0] - 2018-04-10
 ### Added

--- a/lib/python/setup.cfg
+++ b/lib/python/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file=README.md

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -15,6 +15,8 @@ setup(
     ],
     version='2.3.1',
     description='Ridi CMS SDK',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     url='https://github.com/ridi/cms-sdk',
     keywords=['cmssdk', 'ridi', 'ridibooks'],
     classifiers=[

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -13,7 +13,7 @@ setup(
         'ridi.cms.thrift.AdminUser',
         'ridi.cms.thrift.Errors',
     ],
-    version='2.2.6',
+    version='2.3.1',
     description='Ridi CMS SDK',
     url='https://github.com/ridi/cms-sdk',
     keywords=['cmssdk', 'ridi', 'ridibooks'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/cms-sdk",
-  "version": "2.2.6",
+  "version": "2.3.1",
   "description": "Ridibooks CMS SDK",
   "main": "./lib/js/dist/index.js",
   "dependencies": {


### PR DESCRIPTION
Test is done with [cms-bootstrap-python](https://github.com/ridi/cms-bootstrap-python)
Before this PR, a release of cms v2.1.8 is required, which uses cms-sdk v2.3.1-rc.1

## Change List
Add new `authorizeTag` API (#48)