### PR TITLE
Switch order of twig search path

### DIFF
--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -42,9 +42,10 @@ class CmsApplication extends Application
     {
         $this->register(
             new TwigServiceProvider(), [
-                'twig.path' => array_merge([
-                    __DIR__ . '/../views/'
-                ], $this['twig.path'] ?? []),
+                'twig.path' => array_merge(
+                    $this['twig.path'] ?? [],
+                    [__DIR__ . '/../views/']
+                ),
                 'twig.options' => [
                     'cache' => sys_get_temp_dir() . '/twig_cache_v12',
                     'auto_reload' => true,


### PR DESCRIPTION
Currently, due to the priority of twig paths, the file names that already being used for the template files in *cms-sdk* cannot be used from outside of *cms-sdk*. To solve this problem, we should switch the order of twig paths.