### PR TITLE
Change Thrift debug env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [PHP] Use XDEBUG_ENABLE instead DEBUG env for XDebug switch
 
 ## [2.3.3] - 2018-05-24
 ### Added

--- a/lib/php/src/Thrift/ThriftService.php
+++ b/lib/php/src/Thrift/ThriftService.php
@@ -42,7 +42,7 @@ class ThriftService
     {
         $transport = new THttpsClient(self::$host, self::$port, self::$path, self::$scheme);
         $transport->setTimeoutSecs(self::HTTP_TIMEOUT_SECS);
-        if (!empty($_ENV['DEBUG'])) {
+        if (!empty($_ENV['XDEBUG_ENABLE'])) {
             $transport->addHeaders(['Cookie' => 'XDEBUG_SESSION=1']);
         }
 


### PR DESCRIPTION
In some cases, `DEBUG` env is still required even if you don't use XDebug.
I changed to use `XDEBUG_ENABLE` env instead `DEBUG` for the switch of XDebug.