### PR TITLE
Release v2.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.4] - 2018-07-12
+### Added
+- [PHP] Add AuthorizeByTag
 ### Fixed
-- Fixed PaginationHelper not to filter 0 value of query string #54
+- [PHP] Fixed PaginationHelper not to filter 0 value of query string #54
+### Changed
+- [PHP] Use new authorize endpoint `/auth/oauth2/authorize`
 
 ## [2.3.3] - 2018-05-24
 ### Added

--- a/lib/php/src/Auth/AdminAuthService.php
+++ b/lib/php/src/Auth/AdminAuthService.php
@@ -56,10 +56,10 @@ class AdminAuthService
                 $request->getRequestUri()
             );
         } catch (NoTokenException $e) {
-            $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
+            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
             return RedirectResponse::create($redirect_url);
         } catch (MalformedTokenException $e) {
-            $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
+            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
             return RedirectResponse::create($redirect_url);
         } catch (ExpiredTokenException $e) {
             $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
@@ -83,13 +83,13 @@ class AdminAuthService
             $client = ThriftService::getHttpClient('AdminAuth');
             $client->authorizeByTag($token, $tags);
         } catch (NoTokenException $e) {
-            $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
+            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
             return RedirectResponse::create($redirect_url);
         } catch (MalformedTokenException $e) {
-            $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
+            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
             return RedirectResponse::create($redirect_url);
         } catch (ExpiredTokenException $e) {
-            $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
+            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
             return RedirectResponse::create($redirect_url);
         } catch (UnauthorizedException $e) {
             return new Response($e->getMessage(), Response::HTTP_UNAUTHORIZED);

--- a/lib/php/src/Auth/AdminAuthService.php
+++ b/lib/php/src/Auth/AdminAuthService.php
@@ -56,14 +56,11 @@ class AdminAuthService
                 $request->getRequestUri()
             );
         } catch (NoTokenException $e) {
-            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
-            return RedirectResponse::create($redirect_url);
+            return self::createRedirectToAuthorize($request);
         } catch (MalformedTokenException $e) {
-            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
-            return RedirectResponse::create($redirect_url);
+            return self::createRedirectToAuthorize($request);
         } catch (ExpiredTokenException $e) {
-            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
-            return RedirectResponse::create($redirect_url);
+            return self::createRedirectToAuthorize($request);
         } catch (UnauthorizedException $e) {
             if ($request->isXmlHttpRequest()) {
                 return new Response($e->getMessage(), Response::HTTP_UNAUTHORIZED);
@@ -83,17 +80,26 @@ class AdminAuthService
             $client = ThriftService::getHttpClient('AdminAuth');
             $client->authorizeByTag($token, $tags);
         } catch (NoTokenException $e) {
-            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
-            return RedirectResponse::create($redirect_url);
+            return self::createRedirectToAuthorize();
         } catch (MalformedTokenException $e) {
-            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
-            return RedirectResponse::create($redirect_url);
+            return self::createRedirectToAuthorize();
         } catch (ExpiredTokenException $e) {
-            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
-            return RedirectResponse::create($redirect_url);
+            return self::createRedirectToAuthorize();
         } catch (UnauthorizedException $e) {
             return new Response($e->getMessage(), Response::HTTP_UNAUTHORIZED);
         }
+
+        return null;
+    }
+
+    private function createRedirectToAuthorize(?Request $request = null)
+    {
+        if (empty($request)) {
+            $request = Request::createFromGlobals();
+        }
+        $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
+
+        return RedirectResponse::create($redirect_url);
     }
 
     /**

--- a/lib/php/src/Auth/AdminAuthService.php
+++ b/lib/php/src/Auth/AdminAuthService.php
@@ -62,7 +62,7 @@ class AdminAuthService
             $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
             return RedirectResponse::create($redirect_url);
         } catch (ExpiredTokenException $e) {
-            $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
+            $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
             return RedirectResponse::create($redirect_url);
         } catch (UnauthorizedException $e) {
             if ($request->isXmlHttpRequest()) {

--- a/lib/php/src/Auth/AdminAuthService.php
+++ b/lib/php/src/Auth/AdminAuthService.php
@@ -75,6 +75,27 @@ class AdminAuthService
         return null;
     }
 
+    public function authorizeByTag($token, array $tags)
+    {
+        try {
+            $token = LoginService::getAccessToken();
+
+            $client = ThriftService::getHttpClient('AdminAuth');
+            $client->authorizeByTag($token, $tags);
+        } catch (NoTokenException $e) {
+            $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
+            return RedirectResponse::create($redirect_url);
+        } catch (MalformedTokenException $e) {
+            $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
+            return RedirectResponse::create($redirect_url);
+        } catch (ExpiredTokenException $e) {
+            $redirect_url = '/authorize?return_url=' . urlencode($request->getRequestUri());
+            return RedirectResponse::create($redirect_url);
+        } catch (UnauthorizedException $e) {
+            return new Response($e->getMessage(), Response::HTTP_UNAUTHORIZED);
+        }
+    }
+
     /**
      * @throws NoTokenException
      * @throws MalformedTokenException

--- a/lib/php/src/Auth/AdminAuthService.php
+++ b/lib/php/src/Auth/AdminAuthService.php
@@ -56,11 +56,11 @@ class AdminAuthService
                 $request->getRequestUri()
             );
         } catch (NoTokenException $e) {
-            return self::createRedirectToAuthorize($request);
+            return self::createRedirectToAuthorize($request->getRequestUri());
         } catch (MalformedTokenException $e) {
-            return self::createRedirectToAuthorize($request);
+            return self::createRedirectToAuthorize($request->getRequestUri());
         } catch (ExpiredTokenException $e) {
-            return self::createRedirectToAuthorize($request);
+            return self::createRedirectToAuthorize($request->getRequestUri());
         } catch (UnauthorizedException $e) {
             if ($request->isXmlHttpRequest()) {
                 return new Response($e->getMessage(), Response::HTTP_UNAUTHORIZED);
@@ -74,17 +74,19 @@ class AdminAuthService
 
     public function authorizeByTag($token, array $tags)
     {
+        $request = Request::createFromGlobals();
+
         try {
             $token = LoginService::getAccessToken();
 
             $client = ThriftService::getHttpClient('AdminAuth');
             $client->authorizeByTag($token, $tags);
         } catch (NoTokenException $e) {
-            return self::createRedirectToAuthorize();
+            return self::createRedirectToAuthorize($request->getRequestUri());
         } catch (MalformedTokenException $e) {
-            return self::createRedirectToAuthorize();
+            return self::createRedirectToAuthorize($request->getRequestUri());
         } catch (ExpiredTokenException $e) {
-            return self::createRedirectToAuthorize();
+            return self::createRedirectToAuthorize($request->getRequestUri());
         } catch (UnauthorizedException $e) {
             return new Response($e->getMessage(), Response::HTTP_UNAUTHORIZED);
         }
@@ -92,12 +94,9 @@ class AdminAuthService
         return null;
     }
 
-    private function createRedirectToAuthorize(?Request $request = null)
+    private function createRedirectToAuthorize(string $return_url)
     {
-        if (empty($request)) {
-            $request = Request::createFromGlobals();
-        }
-        $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($request->getRequestUri());
+        $redirect_url = '/auth/oauth2/authorize?return_url=' . urlencode($return_url);
 
         return RedirectResponse::create($redirect_url);
     }

--- a/lib/python/ridi/cms/cms_client.py
+++ b/lib/python/ridi/cms/cms_client.py
@@ -13,10 +13,6 @@ from ridi.cms.config import Config
 
 def _createProtocol(service_name, config: Config):
     client = THttpClient.THttpClient(config.RPC_URL)
-    client.setCustomHeaders({
-        'Accept' : 'application/x-thrift',
-        'Content-Type': 'application/x-thrift',
-        })
     protocol = TJSONProtocol.TJSONProtocol(client)
     protocol = TMultiplexedProtocol.TMultiplexedProtocol(protocol, service_name)
     return protocol
@@ -33,8 +29,14 @@ class AdminAuth(AdminAuthService.Client):
         return self.hasHashAuth(None, check_url, login_session.getAdminId())
 
     def getLoginUrl(self, return_url: str = None) -> str:
+        '''Deprecated. Use 'getAuthorizeUrl' instead.'''
         param = '?return_url=%s' % quote_plus(return_url) if return_url else ''
         return '/login' + param
+
+    def getAuthorizeUrl(self, return_url: str = None) -> str:
+        '''Refresh token or Redirect to login page as neccessary.'''
+        param = '?return_url=%s' % quote_plus(return_url) if return_url else ''
+        return '/auth/oauth2/authorize' + param
 
     def authorize(self, login_session: LoginSession, check_url) -> bool:
         return not self.shouldRedirectForLogin(login_session) and \

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -13,7 +13,7 @@ setup(
         'ridi.cms.thrift.AdminUser',
         'ridi.cms.thrift.Errors',
     ],
-    version='2.3.2',
+    version='2.3.4',
     description='Ridi CMS SDK',
     url='https://github.com/ridi/cms-sdk',
     keywords=['cmssdk', 'ridi', 'ridibooks'],


### PR DESCRIPTION
This release is for PHP version of `AuthorizeByTag`, which will be used in CMS-Admin.

## Changes
### Fixed
- [PHP] Fixed PaginationHelper not to filter 0 value of query string #54
- [Python] Add authorize endpoint
### Added
- [PHP] Add `AuthorizeByTag`
### Changed
- [PHP] Use new authorize endpoint `/auth/oauth2/authorize`
