### PR TITLE
Silex 의존성 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# IDE
+.idea
+
 # php
 composer.lock
 vendor

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,11 @@
     "apache/thrift": "^0.10.0",
     "firebase/php-jwt": "^4.0.0",
     "twig/twig": "^2.0",
-    "symfony/http-foundation": "^4.0|^5.0"
+    "symfony/http-foundation": "^4.3"
+  },
+  "suggest": {
+    "laravel/lumen-framework": "Needed to use LumenApplication",
+    "rcrowe/twigbridge": "Needed to use Lumen with Twig"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
   "require": {
     "apache/thrift": "^0.10.0",
     "firebase/php-jwt": "^4.0.0",
-    "silex/silex": "^2.0",
-    "twig/twig": "^2.0"
+    "twig/twig": "^2.0",
+    "symfony/http-foundation": "^4.0|^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -2,21 +2,22 @@
 namespace Ridibooks\Cms;
 
 use Ridibooks\Cms\Auth\LoginService;
+use Ridibooks\Cms\Constants\CmsConfigConst;
 use Ridibooks\Cms\Thrift\ThriftService;
 
 class CmsApplication
 {
     public static function initializeServices($cms_config)
     {
-        ThriftService::setEndPoint($cms_config['thrift.rpc_url'], $cms_config['thrift.rpc_secret']); 
+        ThriftService::setEndPoint($cms_config[CmsConfigConst::THRIFT_RPC_URL], $cms_config[CmsConfigConst::THRIFT_RPC_SECRET]);
 
         $test_id = '';
-        if (!empty($cms_config['debug'])) {
-            $test_id = $cms_config['auth.test_id'];
+        if (!empty($cms_config[CmsConfigConst::DEBUG])) {
+            $test_id = $cms_config[CmsConfigConst::AUTH_TEST_ID];
         }
         LoginService::initialize(
-            $cms_config['auth.cf_access_domain'] ?? '',
-            $cms_config['auth.cf_audience_tag'] ?? '',
+            $cms_config[CmsConfigConst::AUTH_CF_ACCESS_DOMAIN] ?? '',
+            $cms_config[CmsConfigConst::AUTH_CF_AUDIENCE_TAG] ?? '',
             $test_id
         );
     }

--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -40,7 +40,7 @@ class CmsApplication extends Application
         $this->registerSessionServiceProvider();
     }
 
-    static function initializeServices($cms_config)
+    public static function initializeServices($cms_config)
     {
         ThriftService::setEndPoint($cms_config['thrift.rpc_url'], $cms_config['thrift.rpc_secret']); 
 

--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -1,45 +1,11 @@
 <?php
 namespace Ridibooks\Cms;
 
-use Ridibooks\Cms\Auth\AdminAuthService;
 use Ridibooks\Cms\Auth\LoginService;
 use Ridibooks\Cms\Thrift\ThriftService;
-use Silex\Application;
-use Silex\Application\TwigTrait;
-use Silex\Provider\SessionServiceProvider;
-use Silex\Provider\TwigServiceProvider;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class CmsApplication extends Application
+class CmsApplication
 {
-    use TwigTrait;
-
-    const DEFAULT_CONFIG = [
-        'debug' => false,
-        'twig.path' => [],
-        'twig.globals' => [],
-        'thrift.rpc_url' => '',
-        'thrift.rpc_secret' => '',
-        'auth.cf_access_domain' => '',
-        'auth.cf_audience_tag' => '',
-        'auth.test_id' => '',
-    ];
-
-    public function __construct(array $values = [])
-    {
-        parent::__construct(array_merge(
-            self::DEFAULT_CONFIG, 
-            array_filter($values)
-        ));
-
-        $this->setDefaultErrorHandler();
-        self::initializeServices($this);
-        $this->registerTwigServiceProvider();
-        $this->registerSessionServiceProvider();
-    }
-
     public static function initializeServices($cms_config)
     {
         ThriftService::setEndPoint($cms_config['thrift.rpc_url'], $cms_config['thrift.rpc_secret']); 
@@ -53,91 +19,5 @@ class CmsApplication extends Application
             $cms_config['auth.cf_audience_tag'] ?? '',
             $test_id
         );
-    }
-
-    private function setDefaultErrorHandler()
-    {
-        $this->error(function (\Exception $e) {
-            if (empty($this['debug'])) {
-                return null;
-            }
-
-            if ($e instanceof HttpException) {
-                return Response::create($e->getMessage(), $e->getStatusCode(), $e->getHeaders());
-            }
-
-            throw $e;
-        });
-    }
-
-    private function registerTwigServiceProvider()
-    {
-        $this->register(
-            new TwigServiceProvider(), [
-                'twig.path' => array_merge(
-                    $this['twig.path'] ?? [],
-                    [__DIR__ . '/../views/']
-                ),
-                'twig.options' => [
-                    'cache' => sys_get_temp_dir() . '/twig_cache_v12',
-                    'auto_reload' => true,
-                    // TwigServiceProvider에서 기본으로 $this['debug']와 같게 설정되어 있는데 true 일경우
-                    // if xxx is defined로 변수를 일일이 체크해줘야 하는 문제가 있어서 override 함
-                    'strict_variables' => false
-                ],
-            ]
-        );
-
-        // see http://silex.sensiolabs.org/doc/providers/twig.html#customization
-        $this->extend(
-            'twig',
-            function (\Twig_Environment $twig) {
-                $globals = $this['twig.globals'] ?? [];
-                $globals = array_merge($globals, [
-                    'menus' => (new AdminAuthService())->getAdminMenu()
-                ]);
-                foreach ($globals as $k => $v) {
-                    $twig->addGlobal($k, $v);
-                }
-                $twig->addFilter(new \Twig_SimpleFilter('strtotime', 'strtotime'));
-                return $twig;
-            }
-        );
-    }
-
-    private function registerSessionServiceProvider()
-    {
-        $this->register(
-            new SessionServiceProvider(), [
-                'session.storage.handler' => null
-            ]
-        );
-
-        $this['flashes'] = $this->getFlashBag()->all();
-    }
-
-    public function addFlashInfo($message)
-    {
-        $this->getFlashBag()->add('info', $message);
-    }
-
-    public function addFlashSuccess($message)
-    {
-        $this->getFlashBag()->add('success', $message);
-    }
-
-    public function addFlashWarning($message)
-    {
-        $this->getFlashBag()->add('warning', $message);
-    }
-
-    public function addFlashError($message)
-    {
-        $this->getFlashBag()->add('danger', $message);
-    }
-
-    public function getFlashBag(): FlashBag
-    {
-        return $this['session']->getFlashBag();
     }
 }

--- a/lib/php/src/Constants/CmsConfigConst.php
+++ b/lib/php/src/Constants/CmsConfigConst.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms\Constants;
+
+class CmsConfigConst
+{
+    public const DEBUG = 'debug';
+    public const BASE_PATH = 'base.path';
+    public const BASE_CONTROLLER_NAMESPACE = 'base.controller_namespace';
+    public const TWIG_PATH = 'twig.path';
+    public const TWIG_GLOBALS = 'twig.globals';
+    public const THRIFT_RPC_URL = 'thrift.rpc_url';
+    public const THRIFT_RPC_SECRET = 'thrift.rpc_secret';
+    public const AUTH_CF_ACCESS_DOMAIN = 'auth.cf_access_domain';
+    public const AUTH_CF_AUDIENCE_TAG = 'auth.cf_audience_tag';
+    public const AUTH_TEST_ID = 'auth.test_id';
+
+    public const DEFAULT_CONFIG = [
+        self::DEBUG => false,
+        self::BASE_PATH => '',
+        self::BASE_CONTROLLER_NAMESPACE => '',
+        self::TWIG_PATH => [],
+        self::TWIG_GLOBALS => [],
+        self::THRIFT_RPC_URL => '',
+        self::THRIFT_RPC_SECRET => '',
+        self::AUTH_CF_ACCESS_DOMAIN => '',
+        self::AUTH_CF_AUDIENCE_TAG => '',
+        self::AUTH_TEST_ID => '',
+    ];
+}

--- a/lib/php/src/Lumen/CmsAuthorizationMiddleware.php
+++ b/lib/php/src/Lumen/CmsAuthorizationMiddleware.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms\Lumen;
+
+use Ridibooks\Cms\MiniRouter;
+
+class CmsAuthorizationMiddleware
+{
+    public function handle($request, \Closure $next)
+    {
+        $response = MiniRouter::shouldRedirectForLogin($request);
+        if ($response !== null) {
+            return $response;
+        }
+
+        return $next($request);
+    }
+}

--- a/lib/php/src/Lumen/CmsMenuMiddleware.php
+++ b/lib/php/src/Lumen/CmsMenuMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms\Lumen;
+
+use Illuminate\Support\Facades\Config;
+use Ridibooks\Cms\Auth\AdminAuthService;
+
+class CmsMenuMiddleware
+{
+    public function handle($request, \Closure $next)
+    {
+        $cms_menus = (new AdminAuthService())->getAdminMenu();
+
+        $twig_global_config_key = 'twigbridge.twig.globals';
+
+        $twig_globals = Config::get($twig_global_config_key);
+        $twig_globals = array_merge($twig_globals, ['menus' => $cms_menus]);
+        Config::set($twig_global_config_key, $twig_globals);
+
+        return $next($request);
+    }
+}

--- a/lib/php/src/Lumen/CmsMenuMiddleware.php
+++ b/lib/php/src/Lumen/CmsMenuMiddleware.php
@@ -14,9 +14,9 @@ class CmsMenuMiddleware
 
         $twig_global_config_key = 'twigbridge.twig.globals';
 
-        $twig_globals = Config::get($twig_global_config_key);
+        $twig_globals = config($twig_global_config_key);
         $twig_globals = array_merge($twig_globals, ['menus' => $cms_menus]);
-        Config::set($twig_global_config_key, $twig_globals);
+        config([$twig_global_config_key => $twig_globals]);
 
         return $next($request);
     }

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -74,4 +74,29 @@ class LumenApplication
     {
         $this->app->singleton(\Illuminate\Contracts\Console\Kernel::class, $class_name);
     }
+
+    public function addTwigFunction(string $function_name, \Closure $closure): void
+    {
+        $config_key = 'twigbridge.extensions.functions';
+
+        $functions = Config::get($config_key);
+        $functions[$function_name] = $closure;
+        Config::set($config_key, $functions);
+    }
+
+    public function addTwigFilter(string $function_name, \Closure $closure): void
+    {
+        $config_key = 'twigbridge.extensions.filters';
+
+        $filters = Config::get($config_key);
+        $filters[$function_name] = $closure;
+        Config::set($config_key, $filters);
+    }
+
+    public function run(): void
+    {
+        $this->app->register('TwigBridge\ServiceProvider');
+
+        $this->app->run();
+    }
 }

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Ridibooks\Cms\Lumen;
 
+use Illuminate\View\FileViewFinder;
 use Laravel\Lumen\Application;
 use Laravel\Lumen\Bootstrap\LoadEnvironmentVariables;
 use Ridibooks\Cms\CmsApplication;
@@ -52,8 +53,13 @@ class LumenApplication
 
     private function setupView(): void
     {
+        // not use lumen view folder
         $view_paths = array_filter([$this->cms_config['twig.path'], __DIR__ . '/../../views/']);
-        config(['view.paths', $view_paths]); // not use lumen view folder
+        $this->app->extend('view.finder', function ($finder, $app) use ($view_paths) {
+            /** @var FileViewFinder $finder */
+            return $finder->setPaths($view_paths);
+        });
+        config(['view.paths', $view_paths]);
 
         TwigConfigure::buildConfigure($this->app, $this->cms_config);
         $this->app->middleware([CmsMenuMiddleware::class]);

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -54,7 +54,7 @@ class LumenApplication
     private function setupView(): void
     {
         // not use lumen view folder
-        $view_paths = array_filter([$this->cms_config['twig.path'], __DIR__ . '/../../views/']);
+        $view_paths = array_filter(array_merge($this->cms_config['twig.path'], [__DIR__ . '/../../views/']));
         $this->app->extend('view.finder', function ($finder, $app) use ($view_paths) {
             /** @var FileViewFinder $finder */
             return $finder->setPaths($view_paths);

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -46,6 +46,7 @@ class LumenApplication
     private function lumenBootstrap(): void
     {
         (new LoadEnvironmentVariables($this->cms_config['base.path']))->bootstrap();
+        $_ENV['APP_DEBUG'] = $this->cms_config['debug']; // override debug mode
         $this->app = new Application($this->cms_config['base.path']);
 
         $this->app->withFacades();

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms\Lumen;
+
+use Laravel\Lumen\Application;
+use Laravel\Lumen\Bootstrap\LoadEnvironmentVariables;
+use Ridibooks\Cms\CmsApplication;
+use Ridibooks\Cms\MiniRouter;
+use Symfony\Component\HttpFoundation\Request;
+
+class LumenApplication
+{
+    const DEFAULT_CONFIG = [
+        'debug' => false,
+        'base.path' => '',
+        'base.controller_namespace' => '',
+        'twig.path' => [],
+        'twig.globals' => [],
+        'thrift.rpc_url' => '',
+        'thrift.rpc_secret' => '',
+        'auth.cf_access_domain' => '',
+        'auth.cf_audience_tag' => '',
+        'auth.test_id' => '',
+    ];
+
+    /** @var Application */
+    public $app;
+
+    /** @var array */
+    private $cms_config;
+
+    public function __construct(array $cms_config)
+    {
+        $this->cms_config = array_merge(self::DEFAULT_CONFIG, $cms_config);
+        CmsApplication::initializeServices($this->cms_config);
+
+        $request = Request::createFromGlobals();
+        MiniRouter::shouldRedirectForLogin($request);
+
+        $this->lumenBootstrap();
+    }
+
+    private function lumenBootstrap(): void
+    {
+        (new LoadEnvironmentVariables($this->cms_config['base.path']))->bootstrap();
+        $this->app = new Application($this->cms_config['base.path']);
+    }
+
+    public function __call($name, $args)
+    {
+        if (method_exists($this->app, $name)) {
+            return call_user_func_array([$this->app, $name], $args);
+        }
+
+        return call_user_func_array([$this, $name], $args);
+    }
+
+    public function route(\Closure $closure): void
+    {
+        $this->app->router->group(['namespace' => $this->cms_config['base.controller_namespace']], $closure);
+    }
+}

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -7,24 +7,10 @@ use Illuminate\View\FileViewFinder;
 use Laravel\Lumen\Application;
 use Laravel\Lumen\Bootstrap\LoadEnvironmentVariables;
 use Ridibooks\Cms\CmsApplication;
-use Ridibooks\Cms\MiniRouter;
-use Symfony\Component\HttpFoundation\Request;
+use Ridibooks\Cms\Constants\CmsConfigConst;
 
 class LumenApplication
 {
-    const DEFAULT_CONFIG = [
-        'debug' => false,
-        'base.path' => '',
-        'base.controller_namespace' => '',
-        'twig.path' => [],
-        'twig.globals' => [],
-        'thrift.rpc_url' => '',
-        'thrift.rpc_secret' => '',
-        'auth.cf_access_domain' => '',
-        'auth.cf_audience_tag' => '',
-        'auth.test_id' => '',
-    ];
-
     /** @var Application */
     public $app;
 
@@ -33,7 +19,7 @@ class LumenApplication
 
     public function __construct(array $cms_config)
     {
-        $this->cms_config = array_merge(self::DEFAULT_CONFIG, $cms_config);
+        $this->cms_config = array_merge(CmsConfigConst::DEFAULT_CONFIG, $cms_config);
         CmsApplication::initializeServices($this->cms_config);
 
         $this->lumenBootstrap();
@@ -42,9 +28,9 @@ class LumenApplication
 
     private function lumenBootstrap(): void
     {
-        (new LoadEnvironmentVariables($this->cms_config['base.path']))->bootstrap();
-        $_ENV['APP_DEBUG'] = $this->cms_config['debug']; // override debug mode
-        $this->app = new Application($this->cms_config['base.path']);
+        (new LoadEnvironmentVariables($this->cms_config[CmsConfigConst::BASE_PATH]))->bootstrap();
+        $_ENV['APP_DEBUG'] = $this->cms_config[CmsConfigConst::DEBUG]; // override debug mode
+        $this->app = new Application($this->cms_config[CmsConfigConst::BASE_PATH]);
 
         $this->app->withFacades();
     }
@@ -52,7 +38,7 @@ class LumenApplication
     private function setupView(): void
     {
         // not use lumen view folder
-        $view_paths = array_filter(array_merge($this->cms_config['twig.path'], [__DIR__ . '/../../views/']));
+        $view_paths = array_filter(array_merge($this->cms_config[CmsConfigConst::TWIG_PATH], [__DIR__ . '/../../views/']));
         $this->app->extend('view.finder', function ($finder, $app) use ($view_paths) {
             /** @var FileViewFinder $finder */
             return $finder->setPaths($view_paths);
@@ -65,7 +51,7 @@ class LumenApplication
 
     public function route(\Closure $closure): void
     {
-        $this->app->router->group(['namespace' => $this->cms_config['base.controller_namespace']], $closure);
+        $this->app->router->group(['namespace' => $this->cms_config[CmsConfigConst::BASE_CONTROLLER_NAMESPACE]], $closure);
     }
 
     public function registerErrorHandler(string $class_name): void

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Ridibooks\Cms\Lumen;
 
+use Illuminate\Support\Facades\Config;
 use Laravel\Lumen\Application;
 use Laravel\Lumen\Bootstrap\LoadEnvironmentVariables;
 use Ridibooks\Cms\CmsApplication;
@@ -39,12 +40,24 @@ class LumenApplication
         MiniRouter::shouldRedirectForLogin($request);
 
         $this->lumenBootstrap();
+        $this->setupView();
     }
 
     private function lumenBootstrap(): void
     {
         (new LoadEnvironmentVariables($this->cms_config['base.path']))->bootstrap();
         $this->app = new Application($this->cms_config['base.path']);
+
+        $this->app->withFacades();
+    }
+
+    private function setupView(): void
+    {
+        $view_paths = array_filter([$this->cms_config['twig.path'], __DIR__ . '/../../views/']);
+        Config::set('view.paths', $view_paths); // not use lumen view folder
+
+        TwigConfigure::buildConfigure($this->app, $this->cms_config);
+        $this->app->middleware([CmsMenuMiddleware::class]);
     }
 
     public function __call($name, $args)

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Ridibooks\Cms\Lumen;
 
-use Illuminate\Support\Facades\Config;
 use Laravel\Lumen\Application;
 use Laravel\Lumen\Bootstrap\LoadEnvironmentVariables;
 use Ridibooks\Cms\CmsApplication;
@@ -54,7 +53,7 @@ class LumenApplication
     private function setupView(): void
     {
         $view_paths = array_filter([$this->cms_config['twig.path'], __DIR__ . '/../../views/']);
-        Config::set('view.paths', $view_paths); // not use lumen view folder
+        config(['view.paths', $view_paths]); // not use lumen view folder
 
         TwigConfigure::buildConfigure($this->app, $this->cms_config);
         $this->app->middleware([CmsMenuMiddleware::class]);
@@ -79,18 +78,18 @@ class LumenApplication
     {
         $config_key = 'twigbridge.extensions.functions';
 
-        $functions = Config::get($config_key);
+        $functions = config($config_key);
         $functions[$function_name] = $closure;
-        Config::set($config_key, $functions);
+        config([$config_key => $functions]);
     }
 
     public function addTwigFilter(string $function_name, \Closure $closure): void
     {
         $config_key = 'twigbridge.extensions.filters';
 
-        $filters = Config::get($config_key);
+        $filters = config($config_key);
         $filters[$function_name] = $closure;
-        Config::set($config_key, $filters);
+        config([$config_key => $filters]);
     }
 
     public function run(): void

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -60,7 +60,7 @@ class LumenApplication
             /** @var FileViewFinder $finder */
             return $finder->setPaths($view_paths);
         });
-        config(['view.paths', $view_paths]);
+        config(['view.paths' => $view_paths]);
 
         TwigConfigure::buildConfigure($this->app, $this->cms_config);
         $this->app->middleware([CmsMenuMiddleware::class]);

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -36,9 +36,6 @@ class LumenApplication
         $this->cms_config = array_merge(self::DEFAULT_CONFIG, $cms_config);
         CmsApplication::initializeServices($this->cms_config);
 
-        $request = Request::createFromGlobals();
-        MiniRouter::shouldRedirectForLogin($request);
-
         $this->lumenBootstrap();
         $this->setupView();
     }
@@ -97,6 +94,11 @@ class LumenApplication
         $filters = config($config_key);
         $filters[$function_name] = $closure;
         config([$config_key => $filters]);
+    }
+
+    public function enableCmsAuthorizationMiddleware(): void
+    {
+        $this->app->middleware([CmsAuthorizationMiddleware::class]);
     }
 
     public function run(): void

--- a/lib/php/src/Lumen/LumenApplication.php
+++ b/lib/php/src/Lumen/LumenApplication.php
@@ -60,17 +60,18 @@ class LumenApplication
         $this->app->middleware([CmsMenuMiddleware::class]);
     }
 
-    public function __call($name, $args)
-    {
-        if (method_exists($this->app, $name)) {
-            return call_user_func_array([$this->app, $name], $args);
-        }
-
-        return call_user_func_array([$this, $name], $args);
-    }
-
     public function route(\Closure $closure): void
     {
         $this->app->router->group(['namespace' => $this->cms_config['base.controller_namespace']], $closure);
+    }
+
+    public function registerErrorHandler(string $class_name): void
+    {
+        $this->app->singleton(\Illuminate\Contracts\Debug\ExceptionHandler::class, $class_name);
+    }
+
+    public function registerConsoleKernel(string $class_name): void
+    {
+        $this->app->singleton(\Illuminate\Contracts\Console\Kernel::class, $class_name);
     }
 }

--- a/lib/php/src/Lumen/TwigConfigure.php
+++ b/lib/php/src/Lumen/TwigConfigure.php
@@ -113,7 +113,7 @@ class TwigConfigure
                     'TwigBridge\Extension\Loader\Filters',
                     'TwigBridge\Extension\Loader\Functions',
 
-                    'TwigBridge\Extension\Laravel\Auth',
+                    // 'TwigBridge\Extension\Laravel\Auth',
                     'TwigBridge\Extension\Laravel\Config',
                     'TwigBridge\Extension\Laravel\Dump',
                     'TwigBridge\Extension\Laravel\Input',
@@ -121,7 +121,7 @@ class TwigConfigure
                     'TwigBridge\Extension\Laravel\Str',
                     'TwigBridge\Extension\Laravel\Translator',
                     'TwigBridge\Extension\Laravel\Url',
-                    'TwigBridge\Extension\Laravel\Model',
+                    // 'TwigBridge\Extension\Laravel\Model',
                     // 'TwigBridge\Extension\Laravel\Gate',
 
                     // 'TwigBridge\Extension\Laravel\Form',

--- a/lib/php/src/Lumen/TwigConfigure.php
+++ b/lib/php/src/Lumen/TwigConfigure.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms\Lumen;
+
+use Illuminate\Support\Facades\Config;
+use Laravel\Lumen\Application;
+
+// https://github.com/rcrowe/TwigBridge/blob/master/config/twigbridge.php
+class TwigConfigure
+{
+    public static function buildConfigure(Application $app, array $cms_config): void
+    {
+         $configure = [
+            'twig' => [
+                /*
+                |--------------------------------------------------------------------------
+                | Extension
+                |--------------------------------------------------------------------------
+                |
+                | File extension for Twig view files.
+                |
+                */
+                'extension' => 'twig',
+
+                /*
+                |--------------------------------------------------------------------------
+                | Accepts all Twig environment configuration options
+                |--------------------------------------------------------------------------
+                |
+                | http://twig.sensiolabs.org/doc/api.html#environment-options
+                |
+                */
+                'environment' => [
+
+                    // When set to true, the generated templates have a __toString() method
+                    // that you can use to display the generated nodes.
+                    // default: false
+                    'debug' => $cms_config['debug'],
+
+                    // The charset used by the templates.
+                    // default: utf-8
+                    'charset' => 'utf-8',
+
+                    // The base template class to use for generated templates.
+                    // default: TwigBridge\Twig\Template
+                    'base_template_class' => 'TwigBridge\Twig\Template',
+
+                    // An absolute path where to store the compiled templates, or false to disable caching. If null
+                    // then the cache file path is used.
+                    // default: cache file storage path
+                    'cache' => $cms_config['cache_path'] ?? sys_get_temp_dir() . '/twig_cache_v1',
+
+                    // When developing with Twig, it's useful to recompile the template
+                    // whenever the source code changes. If you don't provide a value
+                    // for the auto_reload option, it will be determined automatically based on the debug value.
+                    'auto_reload' => true,
+
+                    // If set to false, Twig will silently ignore invalid variables
+                    // (variables and or attributes/methods that do not exist) and
+                    // replace them with a null value. When set to true, Twig throws an exception instead.
+                    // default: false
+                    'strict_variables' => false,
+
+                    // If set to true, auto-escaping will be enabled by default for all templates.
+                    // default: 'html'
+                    'autoescape' => 'html',
+
+                    // A flag that indicates which optimizations to apply
+                    // (default to -1 -- all optimizations are enabled; set it to 0 to disable)
+                    'optimizations' => -1,
+                ],
+
+                /*
+                |--------------------------------------------------------------------------
+                | Safe Classes
+                |--------------------------------------------------------------------------
+                |
+                | When set, the output of the `__string` method of the following classes will not be escaped.
+                | default: Laravel's Htmlable, which the HtmlString class implements.
+                |
+                */
+                'safe_classes' => [
+                    \Illuminate\Contracts\Support\Htmlable::class => ['html'],
+                ],
+
+                /*
+                |--------------------------------------------------------------------------
+                | Global variables
+                |--------------------------------------------------------------------------
+                |
+                | These will always be passed in and can be accessed as Twig variables.
+                | NOTE: these will be overwritten if you pass data into the view with the same key.
+                |
+                */
+                'globals' => $cms_config['twig.globals'],
+            ],
+
+            'extensions' => [
+
+                /*
+                |--------------------------------------------------------------------------
+                | Extensions
+                |--------------------------------------------------------------------------
+                |
+                | Enabled extensions.
+                |
+                | `Twig\Extension\DebugExtension` is enabled automatically if twig.debug is TRUE.
+                |
+                */
+                'enabled' => [
+                    'TwigBridge\Extension\Loader\Facades',
+                    'TwigBridge\Extension\Loader\Filters',
+                    'TwigBridge\Extension\Loader\Functions',
+
+                    'TwigBridge\Extension\Laravel\Auth',
+                    'TwigBridge\Extension\Laravel\Config',
+                    'TwigBridge\Extension\Laravel\Dump',
+                    'TwigBridge\Extension\Laravel\Input',
+                    'TwigBridge\Extension\Laravel\Session',
+                    'TwigBridge\Extension\Laravel\Str',
+                    'TwigBridge\Extension\Laravel\Translator',
+                    'TwigBridge\Extension\Laravel\Url',
+                    'TwigBridge\Extension\Laravel\Model',
+                    // 'TwigBridge\Extension\Laravel\Gate',
+
+                    // 'TwigBridge\Extension\Laravel\Form',
+                    // 'TwigBridge\Extension\Laravel\Html',
+                    // 'TwigBridge\Extension\Laravel\Legacy\Facades',
+                ],
+
+                /*
+                |--------------------------------------------------------------------------
+                | Facades
+                |--------------------------------------------------------------------------
+                |
+                | Available facades. Access like `{{ Config.get('foo.bar') }}`.
+                |
+                | Each facade can take an optional array of options. To mark the whole facade
+                | as safe you can set the option `'is_safe' => true`. Setting the facade as
+                | safe means that any HTML returned will not be escaped.
+                |
+                | It is advisable to not set the whole facade as safe and instead mark the
+                | each appropriate method as safe for security reasons. You can do that with
+                | the following syntax:
+                |
+                | <code>
+                |     'Form' => [
+                |         'is_safe' => [
+                |             'open'
+                |         ]
+                |     ]
+                | </code>
+                |
+                | The values of the `is_safe` array must match the called method on the facade
+                | in order to be marked as safe.
+                |
+                */
+                'facades' => [],
+
+                /*
+                |--------------------------------------------------------------------------
+                | Functions
+                |--------------------------------------------------------------------------
+                |
+                | Available functions. Access like `{{ secure_url(...) }}`.
+                |
+                | Each function can take an optional array of options. These options are
+                | passed directly to `Twig\TwigFunction`.
+                |
+                | So for example, to mark a function as safe you can do the following:
+                |
+                | <code>
+                |     'link_to' => [
+                |         'is_safe' => ['html']
+                |     ]
+                | </code>
+                |
+                | The options array also takes a `callback` that allows you to name the
+                | function differently in your Twig templates than what it's actually called.
+                |
+                | <code>
+                |     'link' => [
+                |         'callback' => 'link_to'
+                |     ]
+                | </code>
+                |
+                */
+                'functions' => [
+                    'elixir',
+                    'head',
+                    'last',
+                    'mix',
+                ],
+
+                /*
+                |--------------------------------------------------------------------------
+                | Filters
+                |--------------------------------------------------------------------------
+                |
+                | Available filters. Access like `{{ variable|filter }}`.
+                |
+                | Each filter can take an optional array of options. These options are
+                | passed directly to `Twig\TwigFilter`.
+                |
+                | So for example, to mark a filter as safe you can do the following:
+                |
+                | <code>
+                |     'studly_case' => [
+                |         'is_safe' => ['html']
+                |     ]
+                | </code>
+                |
+                | The options array also takes a `callback` that allows you to name the
+                | filter differently in your Twig templates than what is actually called.
+                |
+                | <code>
+                |     'snake' => [
+                |         'callback' => 'snake_case'
+                |     ]
+                | </code>
+                |
+                */
+                'filters' => [
+                    'get' => 'data_get',
+                    'strtotime' => 'strtotime',
+                ],
+            ],
+        ];
+
+        Config::set('twigbridge', $configure);
+    }
+}

--- a/lib/php/src/Lumen/TwigConfigure.php
+++ b/lib/php/src/Lumen/TwigConfigure.php
@@ -117,10 +117,10 @@ class TwigConfigure
                     'TwigBridge\Extension\Laravel\Config',
                     'TwigBridge\Extension\Laravel\Dump',
                     'TwigBridge\Extension\Laravel\Input',
-                    'TwigBridge\Extension\Laravel\Session',
+                    // 'TwigBridge\Extension\Laravel\Session',
                     'TwigBridge\Extension\Laravel\Str',
-                    'TwigBridge\Extension\Laravel\Translator',
-                    'TwigBridge\Extension\Laravel\Url',
+                    // 'TwigBridge\Extension\Laravel\Translator',
+                    // 'TwigBridge\Extension\Laravel\Url',
                     // 'TwigBridge\Extension\Laravel\Model',
                     // 'TwigBridge\Extension\Laravel\Gate',
 

--- a/lib/php/src/Lumen/TwigConfigure.php
+++ b/lib/php/src/Lumen/TwigConfigure.php
@@ -228,6 +228,6 @@ class TwigConfigure
             ],
         ];
 
-        Config::set('twigbridge', $configure);
+        config(['twigbridge' => $configure]);
     }
 }

--- a/lib/php/src/MiniRouter.php
+++ b/lib/php/src/MiniRouter.php
@@ -108,13 +108,19 @@ class MiniRouter
     {
         $view_file_name = $query . '.twig';
 
-        $app = new CmsApplication(array_merge($this->cms_config, [
-            'twig.path' => [$this->view_dir],
+        $twig = new TwigHelper(array_merge($this->cms_config, [
+            'view_root_path' => [$this->view_dir, __DIR__ . '/../views/'],
         ]));
-        /** @var \Twig_Environment $twig_helper */
-        $twig_helper = $app['twig'];
 
-        return Response::create($twig_helper->render($view_file_name, $args));
+        $globals = $this->cms_config['twig.globals'] ?? [];
+        $globals = array_merge($globals, [
+            'menus' => (new AdminAuthService())->getAdminMenu()
+        ]);
+        foreach ($globals as $k => $v) {
+            $twig->addGlobal($k, $v);
+        }
+
+        return Response::create($twig->render($view_file_name, $args));
     }
 
     private static function notFound()

--- a/lib/php/src/MiniRouter.php
+++ b/lib/php/src/MiniRouter.php
@@ -2,6 +2,7 @@
 namespace Ridibooks\Cms;
 
 use Ridibooks\Cms\Auth\AdminAuthService;
+use Ridibooks\Cms\Constants\CmsConfigConst;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -104,7 +105,7 @@ class MiniRouter
             'view_root_path' => [$this->view_dir, __DIR__ . '/../views/'],
         ]));
 
-        $globals = $this->cms_config['twig.globals'] ?? [];
+        $globals = $this->cms_config[CmsConfigConst::TWIG_GLOBALS] ?? [];
         $globals = array_merge($globals, [
             'menus' => (new AdminAuthService())->getAdminMenu()
         ]);

--- a/lib/php/src/TwigHelper.php
+++ b/lib/php/src/TwigHelper.php
@@ -49,10 +49,8 @@ class TwigHelper
         return $this;
     }
 
-    public function render(string $view_file_path, $context): self
+    public function render(string $view_file_path, $context): string
     {
-        $this->twig->render($view_file_path, $context);
-
-        return $this;
+        return $this->twig->render($view_file_path, $context);
     }
 }

--- a/lib/php/src/TwigHelper.php
+++ b/lib/php/src/TwigHelper.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Ridibooks\Cms;
+
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFilter;
+
+class TwigHelper
+{
+    /** @var Environment */
+    private $twig;
+
+    public function __construct(array $options)
+    {
+        $this->create($options);
+        $this->addPHPFunction('strtotime');
+    }
+
+    private function create(array $options): void
+    {
+        $view_root_path = $options['view_root_path'] ?? [];
+        $filesystem_loader = new FilesystemLoader($view_root_path);
+
+        $twig_options = array_merge([
+            'cache' => $options['cache_path'] ?? sys_get_temp_dir() . '/twig_cache_v1',
+            'auto_reload' => true,
+        ], $options);
+
+        $this->twig = new Environment($filesystem_loader, $twig_options);
+    }
+
+    public function addPHPFunction(string $func): self
+    {
+        if (!function_exists($func)) {
+            throw new \InvalidArgumentException("Not Exists function: {$func}");
+        }
+
+        $this->twig->addFilter(new TwigFilter($func, $func));
+
+        return $this;
+    }
+
+    public function addGlobal(string $key, $value): self
+    {
+        $this->twig->addGlobal($key, $value);
+
+        return $this;
+    }
+
+    public function render(string $view_file_path, $context): self
+    {
+        $this->twig->render($view_file_path, $context);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
## 주요 변경점
- `Silex` 참조 제거
  - `CmsApplication` 이 상속하고 있던 Silex `Application` 을 제거
  - `CmsApplication` 에 구현 되어 있던 method 들 정리 및 제거
- `MiniRouter` 관련 정리
  - `MiniRouter` 에서 사용할 `TwigHelper` 생성 및 설정 정리
  - 불필요한 `static` 제거
- `Lumen` 패키지 기반인 `LumenApplication` 추가
  - `Twig` 을 사용하기 위해 `TwigBrigde` 관련 설정 추가
  - `$cms_config` 설정값 추가
    - `base.path`: Application root path 설정
    - `base.controller_namespace`: Controller 들이 위치한 namespace 기재

## 사용처별 교체 방법
### `MiniRouter`
- 조치할 내용 없음

### Silex -> Lumen 교체
- composer.json 설정
  - `laravel/lumen-framework`: ^6.0
  - `rcrowe/twigbridge`: ^0.11
- `vlucas/phpdotenv` 버전 체크
  - ^3.3 이상 설정, load 부분 변경 필요
- `$cms_config` 에 `base.path`, `base.controller_namespace` 설정
- Lumen 관련 추가 설정
  - Request class 교체
    - `Symfony\Component\HttpFoundation\Request` -> `Illuminate\Http\Request`
  - `ErrorHandler` 생성해서 등록
    - 등록: https://gitlab.com/ridicorp/platform/operation/-/blob/8d0cbfa33d7144e2364724f0083c7be23be31737/src/Library/Application.php#L35
    - class: https://gitlab.com/ridicorp/platform/operation/-/blob/8d0cbfa33d7144e2364724f0083c7be23be31737/src/Library/ExceptionHandler.php
  - 라우팅 변경
    - `LumenApplication::route()` 를 이용하면 namespace 설정을 기본값으로 사용하기때문에 설정이 편함
    - Application 설정: https://gitlab.com/ridicorp/platform/operation/-/blob/8d0cbfa33d7144e2364724f0083c7be23be31737/src/Library/Application.php#L44
    - Controller 설정: https://gitlab.com/ridicorp/platform/operation/-/blob/8d0cbfa33d7144e2364724f0083c7be23be31737/src/Controller/DownloadController.php#L12

## 참고사항
- Lumen 사용법이 라우팅을 제외하고 거의 모두 Laravel 과 동일하기에 Laravel 메뉴얼을 참고하는 것이 좋음
  - Lumen: https://lumen.laravel.com/docs/6.x
  - Laravel(한글): https://laravel.kr/docs/6.x