### PR TITLE
Add cache on cms menu loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [3.1] - 2020-11-27
+### Changed
 - [BC BREAK] [PHP] Add cache for getting cms menu 
 (you must inject PSR-6 implementation to CmsApplication)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.1] - 2020-11-27
+- [BC BREAK] [PHP] Add cache for getting cms menu 
+(you must inject PSR-6 implementation to CmsApplication)
+
 ## [3.0.5] - 2020-05-12
 - [PHP] Fix jwt validation error
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "firebase/php-jwt": "^4.0.0",
     "silex/silex": "^2.0",
     "twig/twig": "^2.0",
-    "symfony/cache": "~3.4"
+    "symfony/cache": "^3.4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "firebase/php-jwt": "^4.0.0",
     "silex/silex": "^2.0",
     "twig/twig": "^2.0",
-    "symfony/cache": "^5.1"
+    "symfony/cache": "~3.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "apache/thrift": "^0.10.0",
     "firebase/php-jwt": "^4.0.0",
     "silex/silex": "^2.0",
-    "twig/twig": "^2.0"
+    "twig/twig": "^2.0",
+    "symfony/cache": "^5.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,24 @@
 {
-  "name": "ridibooks/cms-sdk",
-  "description": "Ridibooks CMS SDK",
-  "type": "library",
-  "license": "MIT",
-  "require": {
-    "apache/thrift": "^0.10.0",
-    "firebase/php-jwt": "^4.0.0",
-    "silex/silex": "^2.0",
-    "twig/twig": "^2.0",
-    "symfony/cache": "^3.4"
-  },
-  "autoload": {
-    "psr-4": {
-      "Ridibooks\\Cms\\": "lib/php/src"
+    "name": "ridibooks/cms-sdk",
+    "description": "Ridibooks CMS SDK",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "apache/thrift": "^0.10.0",
+        "firebase/php-jwt": "^4.0.0",
+        "silex/silex": "^2.0",
+        "twig/twig": "^2.0",
+        "psr/cache": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ridibooks\\Cms\\": "lib/php/src"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.5"
+    },
+    "scripts": {
+        "test": "phpunit lib/php"
     }
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^6.5"
-  },
-  "scripts": {
-    "test": "phpunit lib/php"
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "firebase/php-jwt": "^4.0.0",
     "silex/silex": "^2.0",
     "twig/twig": "^2.0",
-    "symfony/cache": "~3.0"
+    "symfony/cache": "~3.4"
   },
   "autoload": {
     "psr-4": {

--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -97,9 +97,9 @@ class CmsApplication extends Application
                 if (!$cached_menu->isHit()) {
                     $menu = (new AdminAuthService())->getAdminMenu();
                     $cached_menu->set($menu);
-                    
+
                     $under_dev = $this['debug'] ?? false;
-                    $cached_menu->expiresAfter($under_dev ? 1*60 : 24*3600);
+                    $cached_menu->expiresAfter($under_dev ? 24*3600 : 1*60);
                     $cache->save($cached_menu);
                 }
 

--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -106,7 +106,7 @@ class CmsApplication extends Application
 
                 $globals = $this['twig.globals'] ?? [];
                 $globals = array_merge($globals, [
-                    'menus' => $cached_menu
+                    'menus' => $cached_menu->get()
                 ]);
                 foreach ($globals as $k => $v) {
                     $twig->addGlobal($k, $v);

--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -95,14 +95,11 @@ class CmsApplication extends Application
             'twig',
             function (\Twig_Environment $twig) {
                 $cache = new ApcuAdapter();
-                $key = 'menu';
-
-                $menu = $cache->get($key, function (ItemInterface $item) {
+                $menu = $cache->get('menu', function (ItemInterface $item) {
                     $ttl = empty($this['debug']) ? 1*60 : 24*3600;
                     $item->expiresAfter($ttl);
 
-                    $result = (new AdminAuthService())->getAdminMenu();
-                    return $result;
+                    return (new AdminAuthService())->getAdminMenu();
                 });
                 $globals = $this['twig.globals'] ?? [];
                 $globals = array_merge($globals, [

--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -98,7 +98,7 @@ class CmsApplication extends Application
                     $menu = (new AdminAuthService())->getAdminMenu();
                     $cached_menu->set($menu);
 
-                    $cached_menu->expiresAfter(empty($this['debug']) ? 1*60 : 24*3600);
+                    $cached_menu->expiresAfter($this['debug'] ? 1*60 : 24*3600);
                     $cache->save($cached_menu);
                 }
 

--- a/lib/php/src/CmsApplication.php
+++ b/lib/php/src/CmsApplication.php
@@ -97,8 +97,9 @@ class CmsApplication extends Application
                 if (!$cached_menu->isHit()) {
                     $menu = (new AdminAuthService())->getAdminMenu();
                     $cached_menu->set($menu);
-
-                    $cached_menu->expiresAfter($this['debug'] ? 1*60 : 24*3600);
+                    
+                    $under_dev = $this['debug'] ?? false;
+                    $cached_menu->expiresAfter($under_dev ? 1*60 : 24*3600);
                     $cache->save($cached_menu);
                 }
 

--- a/lib/php/src/MiniRouter.php
+++ b/lib/php/src/MiniRouter.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ridibooks\Cms;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Ridibooks\Cms\Auth\AdminAuthService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,13 +16,20 @@ class MiniRouter
      */
     private $app;
     private $cms_config;
+    private $cache;
 
-    public function __construct($controller_dir, $view_dir, $prefix_uri = '', $cms_config = [])
-    {
+    public function __construct(
+        $controller_dir,
+        $view_dir,
+        $prefix_uri = '',
+        $cms_config = [],
+        CacheItemPoolInterface $cache
+    ) {
         $this->controller_dir = $controller_dir;
         $this->view_dir = $view_dir;
         $this->prefix_uri = self::getNormalizedUri($prefix_uri);
         $this->cms_config = $cms_config;
+        $this->cache = $cache;
         CmsApplication::initializeServices($cms_config);
     }
 
@@ -110,7 +118,7 @@ class MiniRouter
 
         $app = new CmsApplication(array_merge($this->cms_config, [
             'twig.path' => [$this->view_dir],
-        ]));
+        ]), $this->cache);
         /** @var \Twig_Environment $twig_helper */
         $twig_helper = $app['twig'];
 


### PR DESCRIPTION
# 💡  무엇이 문제인가
로컬에서 CMS 개발할 때 너무 느려서 원인을 조사했습니다. `$app['twig']->render` 로 화면을 보여줄 때 마다, CMS SDK에서 twig global 설정에 CMS 메뉴 정보를 가져와서 담는 사실을 알게 되었고, 이 과정이 전체 로딩 시간의 대부분을 차지하는 것으로 파악했습니다.

메뉴를 가져올 때 캐시를 적용하고, 개발 환경일 때는 캐시 TTL을 무척 길게 잡아서 개발 환경의 불편함을 최소화하고자 했습니다.

PSR-6 인터페이스를 주입받습니다.

# 결과

로컬 서점 CMS기준, 페이지 로딩 당 20초씩 걸리던 요청이 1초대로 성능 향상이 되었습니다.

![스크린샷 2020-11-27 오후 2 18 34](https://user-images.githubusercontent.com/1160378/100413801-91ea4880-30bb-11eb-8c07-486798565354.png)


# 👀  눈여겨볼 부분 

- 캐시 TTL이 적당한지 (더 낮추거나, 또는 늘려야 할 필요는 없을지)